### PR TITLE
Proposed fix for issue #15

### DIFF
--- a/calculator/webpa/classes/calculator.php
+++ b/calculator/webpa/classes/calculator.php
@@ -120,6 +120,11 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
         foreach ($memberids as $memberid) {
             $gradesgiven = $totalscores[$memberid];
             $total = array_sum($gradesgiven);
+            if($total == 0) { // in the event of a total non-submission...
+                foreach($gradesgiven as $grade) {
+                    $gradesgiven[$grade] += 1; // ...replace all grades given (all zeros) with ones
+                }
+            }
 
             $fracscores[$memberid] = array_reduce(array_keys($gradesgiven), function($carry, $peerid) use ($total, $gradesgiven) {
                 $grade = $gradesgiven[$peerid];
@@ -145,7 +150,7 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
 
         // Apply the fudge factor to all scores received.
         $nummembers = count($memberids);
-        $fudgefactor = $numsubmitted > 0 ? $nummembers / $numsubmitted : 1;
+        $fudgefactor = 1; //$numsubmitted > 0 ? $nummembers / $numsubmitted : 1; // "fudge factor" unfairly favors non-submitters - set it to one since non-submissions have been replaced with straight ones above
         $webpascores = array_map(function($grade) use ($fudgefactor) {
             return $grade * $fudgefactor;
         }, $webpascores);

--- a/calculator/webpa/classes/calculator.php
+++ b/calculator/webpa/classes/calculator.php
@@ -119,9 +119,11 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
         foreach ($memberids as $memberid) {
             $gradesgiven = $totalscores[$memberid];
             $total = array_sum($gradesgiven);
-            if($total == 0) { // in the event of a total non-submission...
+            if($total == 0) { // in the event of a non-submission...
                 foreach($gradesgiven as $key => $grade) {
-                    $gradesgiven[$key] = 1; // ...replace all grades given (all zeros) with ones
+                    if($memberid != $key || $selfgrade)
+                        $gradesgiven[$key] = 1; // ...replace relevant grades given (all zeros) with ones
+                    }
                 }
                 $total = array_sum($gradesgiven);
             }

--- a/calculator/webpa/classes/calculator.php
+++ b/calculator/webpa/classes/calculator.php
@@ -113,6 +113,9 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
 
                     $totalscores[$graderid][$memberid] = $sum;
                 }
+                else {
+                    $totalscores[$graderid][$memberid] = 0; // zero must be inserted if a grade is not set
+                }
             }
         }
 

--- a/calculator/webpa/classes/calculator.php
+++ b/calculator/webpa/classes/calculator.php
@@ -101,10 +101,6 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
         // Calculate the total scores.
         foreach ($memberids as $memberid) {
             foreach ($grades as $graderid => $gradesgiven) {
-                if (!isset($totalscores[$graderid])) {
-                    $totalscores[$graderid] = [];
-                }
-
                 if (isset($gradesgiven[$memberid])) {
                     $sum = array_reduce($gradesgiven[$memberid], function($carry, $item) {
                         $carry += $item;
@@ -124,9 +120,10 @@ class calculator extends \mod_peerwork\peerworkcalculator_plugin {
             $gradesgiven = $totalscores[$memberid];
             $total = array_sum($gradesgiven);
             if($total == 0) { // in the event of a total non-submission...
-                foreach($gradesgiven as $grade) {
-                    $gradesgiven[$grade] += 1; // ...replace all grades given (all zeros) with ones
+                foreach($gradesgiven as $key => $grade) {
+                    $gradesgiven[$key] = 1; // ...replace all grades given (all zeros) with ones
                 }
+                $total = array_sum($gradesgiven);
             }
 
             $fracscores[$memberid] = array_reduce(array_keys($gradesgiven), function($carry, $peerid) use ($total, $gradesgiven) {


### PR DESCRIPTION
The "fudge factor" to deal with non-submission of PA marks always boosts the PA result of the non-submitter. This proposed fix responds to this by setting the fudge factor to 1, and inserting a mark of one against all other team members on behalf of someone who doesn't repsond. Issue #15 describes the problem and the fix in full detail.