### PR TITLE
Valid default setting for calculator

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -127,7 +127,7 @@ if ($ADMIN->fulltree) {
         'peerwork/calculator',
         get_string('calculator', 'mod_peerwork'),
         get_string('calculator_help', 'mod_peerwork'),
-        0,
+        'webpa',
         $calcoptions
     ));
 


### PR DESCRIPTION
The default setting for calculator is 0, which isn't a valid choice out of the options. This causes these two core unit tests to fail:

* `\core\adminlib_test::test_admin_output_new_settings_by_page`
* `\core\adminlib_test::test_admin_apply_default_settings`

We can probably assume that the webpa calculator is available since it's bundled with the plugin, so it would be better to use that.