### PR TITLE
update deprecated behat step to supported alternative

### DIFF
--- a/tests/behat/group_restriction.feature
+++ b/tests/behat/group_restriction.feature
@@ -36,7 +36,7 @@ Feature: Group availability
   Scenario: Teachers can unlock submissions
     Given I log in as "teacher1"
     And I am on "Course 1" course homepage with editing mode on
-    And I add a "Peer Assessment" to section "1"
+    And I add a "peerwork" activity to course "Course 1" section "1"
     And I set the following fields to these values:
       | Peer assessment         | Test peerwork name        |
       | Description             | Test peerwork description |


### PR DESCRIPTION
Avoids warning about deprecated step:

```
Exception: Deprecated step, rather than using this step you can:
        - behat_course::i_add_to_course_section
        - behat_course::i_add_to_section_using_the_activity_chooser
        - Set $CFG->behat_usedeprecated in config.php to allow the use of deprecated steps
```