### PR TITLE
Remove PREVIOUS and NEXT attributes from grade field

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -44,7 +44,7 @@
                 <FIELD NAME="peerworkid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The group id for team submissions"/>
                 <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-                <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" PREVIOUS="userid" NEXT="paweighting"/>
+                <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5"/>
                 <FIELD NAME="paweighting" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="50" SEQUENCE="false"/>
                 <FIELD NAME="feedbacktext" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
                 <FIELD NAME="feedbackformat" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false"/>


### PR DESCRIPTION
The current install.xml contains some of the obsolete PREVIOUS / NEXT fields and causes the core unit test `core\db\plugin_checks_test::test_db_install_file` to fail. This patch removes them to prevent the failure.

`2) core\db\plugin_checks_test::test_db_install_file with data set "mod_peerwork" ('mod_peerwork', 'mod', 'peerwork', '/var/www/html/public/mod/peerwork')
XMLDB structure does not match the install.xml file in /var/www/html/public/mod/peerwork/db/install.xml
Failed asserting that two DOM documents are equal.`